### PR TITLE
--pass-args flag

### DIFF
--- a/data/help.js
+++ b/data/help.js
@@ -14,5 +14,9 @@ module.exports = [
   {
     "flag": "--system_alias",
     "description": "Show list of system reserved aliases."
+  },
+  {
+    "flag": "--pass-args",
+    "description": "Arguments called on the alias will be passed to the command. Use when creating the alias"
   }
 ];

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,10 +3,12 @@ module.exports = {
   HELP: '--help',
   LIST: '--list',
   SYSTEM_ALIAS: '--system_alias',
+  PASS_ARGS: '--pass-args',
   ROOT_DIR: '/usr/local/.squash',
   FLAGS: {
     HELP: 'FLAG_HELP',
     LIST: 'FLAG_LIST',
     SYSTEM_ALIAS: 'FLAG_SYSTEM_ALIAS',
+    PASS_ARGS: 'FLAG_PASS_ARGS',
   },
 }

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -16,6 +16,9 @@ externals.parseFlags = (flags) => {
       case CONSTANTS.SYSTEM_ALIAS:
         parsedFlags.push(CONSTANTS.FLAGS.SYSTEM_ALIAS);
         break;
+      case CONSTANTS.PASS_ARGS:
+        parsedFlags.push(CONSTANTS.FLAGS.PASS_ARGS);
+        break;
     }
   }
   return parsedFlags;

--- a/lib/squash.js
+++ b/lib/squash.js
@@ -30,11 +30,7 @@ const squash = (args) => {
     Util.createDirectory();
   }
 
-  if (Flags.parseFlags(flags).indexOf(CONSTANTS.FLAGS.PASS_ARGS) > -1) {
-    FileOps.createCommand(alias, `${command} "$@"`);
-  } else {
-    FileOps.createCommand(alias, command);
-  }
+  FileOps.createCommand(alias, Util.formatCommand(command, flags));
 }
 
 

--- a/lib/squash.js
+++ b/lib/squash.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const Util = require('./util');
 const Valdiations = require('./validations');
 const FileOps = require('./file-operations');
+const Flags = require('./flags');
 
 const CONSTANTS = require('./constants');
 
@@ -29,7 +30,11 @@ const squash = (args) => {
     Util.createDirectory();
   }
 
-  FileOps.createCommand(alias, command);
+  if (Flags.parseFlags(flags).indexOf(CONSTANTS.FLAGS.PASS_ARGS) > -1) {
+    FileOps.createCommand(alias, `${command} "$@"`);
+  } else {
+    FileOps.createCommand(alias, command);
+  }
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,7 @@ externals.parserInput = (inputArgs) => {
         alias = inputArgs[i].replace(CONSTANTS.ALIAS, '')
         flags.push(param);
         break;
+      case CONSTANTS.PASS_ARGS:
       case CONSTANTS.LIST:
       case CONSTANTS.HELP:
         flags.push(param);

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,5 +113,16 @@ externals.systemAlias = (systemAlias) => {
   }
 }
 
+externals.formatCommand = (command, flags) => {
+  let formatedCommand = command;
+  for (let i in flags) {
+    switch (flags[i]) {
+      case CONSTANTS.PASS_ARGS:
+        formatedCommand = `${command} "$@"`;
+        break;
+    }
+  }
+  return formatedCommand;
+}
 
 module.exports = externals

--- a/tests/local.js
+++ b/tests/local.js
@@ -11,16 +11,22 @@ const squash = require('../lib/squash');
 const CONSTANTS = require('../lib/constants');
 
 const SQUASH_FLAG = [ 'ls', '--alias=squashed' ];
+const SQUASH_PASS_ARGS = [ 'ls', '--alias=passed-args', '--pass-args'];
 
-const FILE_NAME = 'squashed';
-
-const validateFileContent = () => {
+const validateFileContent = (file, flag) => {
   return new Promise(function(resolve, reject){
-    fs.readFile(`${CONSTANTS.ROOT_DIR}/${FILE_NAME}`, 'utf-8', function(err, content) {
+    fs.readFile(`${CONSTANTS.ROOT_DIR}/${file}`, 'utf-8', function(err, content) {
       if (err) {
         reject(err);
       }
-      expect(content).to.equal(SQUASH_FLAG[0]);
+      switch (flag) {
+        case CONSTANTS.PASS_ARGS:
+          expect(content).to.equal(`${SQUASH_PASS_ARGS[0]} "$@"`);
+          break;
+        default:
+          expect(content).to.equal(SQUASH_FLAG[0]);
+          break;
+      }
       resolve();
     });
   })
@@ -52,6 +58,24 @@ describe('Validating squash created', function() {
     expect(console.log.getCall(10).args[0]).to.equal('###       #############  ########      ######  ########  ####        ######  ########  ##');
     expect(console.log.getCall(11).args[0]).to.equal('#########################################################################################');
     expect(console.log.getCall(12).args[0]).to.equal('\n');
-    await validateFileContent();
+    await validateFileContent("squashed");
+  });
+  it('squash a command with --pass-args', async () => {
+    squash(SQUASH_PASS_ARGS);
+    assert.isTrue(console.log.called, "log should have been called.");
+    expect(console.log.getCall(0).args[0]).to.equal('\n');
+    expect(console.log.getCall(1).args[0]).to.equal('#########################################################################################');
+    expect(console.log.getCall(2).args[0]).to.equal('####       ######        #####  ########  #####        ########        ####  ########  ##');
+    expect(console.log.getCall(3).args[0]).to.equal('###  ###########  ######  ####  ########  ####  ######  #####  ############  ########  ##');
+    expect(console.log.getCall(4).args[0]).to.equal('##  ###########  ########  ###  ########  ###  ########  ###  #############  ########  ##');
+    expect(console.log.getCall(5).args[0]).to.equal('###  ##########  ########  ###  ########  ###  ########  ####  ############  ########  ##');
+    expect(console.log.getCall(6).args[0]).to.equal('####       ####  ########  ###  ########  ###  ########  #####         ####            ##');
+    expect(console.log.getCall(7).args[0]).to.equal('#########   ###  ########  ###  ########  ###            ############  ####  ########  ##');
+    expect(console.log.getCall(8).args[0]).to.equal('##########  ####  ######  ####  ########  ###  ########  #############  ###  ########  ##');
+    expect(console.log.getCall(9).args[0]).to.equal('#########  ######       #######  ######  ####  ########  ############  ####  ########  ##');
+    expect(console.log.getCall(10).args[0]).to.equal('###       #############  ########      ######  ########  ####        ######  ########  ##');
+    expect(console.log.getCall(11).args[0]).to.equal('#########################################################################################');
+    expect(console.log.getCall(12).args[0]).to.equal('\n');
+    await validateFileContent("passed-args", CONSTANTS.PASS_ARGS);
   });
 })

--- a/tests/test.js
+++ b/tests/test.js
@@ -59,11 +59,12 @@ describe('Verifies async features', function() {
     expect(console.log.getCall(19).args[0]).to.equal('\t--list\t :  \tLists all the commands which are saved using squash.');
     expect(console.log.getCall(20).args[0]).to.equal('\t--help\t :  \tShow details of Squash.');
     expect(console.log.getCall(21).args[0]).to.equal('\t--system_alias\t :  \tShow list of system reserved aliases.');
-    expect(console.log.getCall(22).args[0]).to.equal('\n');
-    expect(console.log.getCall(23).args[0]).to.equal('Notes');
-    expect(console.log.getCall(24).args[0]).to.equal(' ✔ Provide absolute path of the files/directory, if the commands uses any file/directory from your system');
-    expect(console.log.getCall(25).args[0]).to.equal(' ✔ Wrap the command in double quotes (""), if command comprises of spaces or special characters');
-    expect(console.log.getCall(26).args[0]).to.equal('\n\n');
+    expect(console.log.getCall(22).args[0]).to.equal('\t--pass-args\t :  \tArguments called on the alias will be passed to the command. Use when creating the alias');
+    expect(console.log.getCall(23).args[0]).to.equal('\n');
+    expect(console.log.getCall(24).args[0]).to.equal('Notes');
+    expect(console.log.getCall(25).args[0]).to.equal(' ✔ Provide absolute path of the files/directory, if the commands uses any file/directory from your system');
+    expect(console.log.getCall(26).args[0]).to.equal(' ✔ Wrap the command in double quotes (""), if command comprises of spaces or special characters');
+    expect(console.log.getCall(27).args[0]).to.equal('\n\n');
   });
 
   it('prints all sysytem aliases', function(){


### PR DESCRIPTION
When calling squash with the --pass-args flag: "$@" will be added to the end of the sh file

Fixes #46 

Check everything which applies

- [x] I have added the issue number for which this pull request is created.
