### PR TITLE
Run local tests in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "node"
   
+before_install:
+  - sudo chmod 777 /usr/local/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "pretest": "eslint --ignore-path .gitignore .",
-    "test": "node_modules/mocha/bin/mocha tests/test.js"
+    "test": "node_modules/mocha/bin/mocha tests/"
   },
   "bin": {
     "squash": "index.js"


### PR DESCRIPTION
Fixes #72 

Changing the `/usr/local/` folder permissions before the install solved the issue with the tests in Travis. This will run the tests fine but I think that on the long run it will be better to change the folder where squash stores the sh files to somewhere we don't have to change permissions.

Check everything which applies

- [x] I have added the issue number for which this pull request is created.
