### PR TITLE
Sign commands (List rewrite)

### DIFF
--- a/lib/file-operations/command-create.js
+++ b/lib/file-operations/command-create.js
@@ -6,8 +6,11 @@ const CONSTANTS = require('../util/constants');
 const commandCreate = (alias, command) => {
 
   try {
+    // Add signature comment at first line (needed for the list command)
+    let content = `# ${CONSTANTS.SIGNATURE}\n${command}`;
+
     // Create a sh file with the input command
-    fs.writeFileSync(`${CONSTANTS.ROOT_DIR}/${alias}`, command, 'utf8');
+    fs.writeFileSync(`${CONSTANTS.ROOT_DIR}/${alias}`, content, 'utf8');
     console.log('The file was succesfully saved!');
 
     // Giving executable permission to the file

--- a/lib/file-operations/commands-list.js
+++ b/lib/file-operations/commands-list.js
@@ -18,8 +18,10 @@ const commandsList = () => {
     // Reading every file and logging its content
     filenames.forEach( async (filename) => {
       try {
-        const content = fs.readFileSync(`${CONSTANTS.ROOT_DIR}/${filename}`, 'utf-8');
-        console.log(`${filename}  ->  ${content}\n`);
+        const content = fs.readFileSync(`${CONSTANTS.ROOT_DIR}/${filename}`, 'utf-8').split('\n');
+        if (content[0] === `# ${CONSTANTS.SIGNATURE}`) {
+          console.log(`${filename}  ->  ${content[1]}\n`);
+        }
       } catch (err) {
         console.log('Error', err);
         return;

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -7,6 +7,7 @@ const constants = {
   PASS_ARGS: '--pass-args',
   VERSION: '--version',
   ROOT_DIR: '/usr/local/.squash',
+  SIGNATURE: 'Created by squash',
   FLAGS: {
     HELP: 'FLAG_HELP',
     LIST: 'FLAG_LIST',

--- a/tests/test.js
+++ b/tests/test.js
@@ -18,13 +18,14 @@ const SQUASH_PASS_ARGS = ['ls', '--alias=squashed', '--pass-args'];
 const PACKAGE_CONFIG = require('../package.json');
 
 const validateFileContent = (file, flag) => {
-  const content = fs.readFileSync(`${CONSTANTS.ROOT_DIR}/${file}`, 'utf-8');
+  const content = fs.readFileSync(`${CONSTANTS.ROOT_DIR}/${file}`, 'utf-8').split('\n');
+  expect(content[0]).to.equal(`# ${CONSTANTS.SIGNATURE}`);
   switch (flag) {
     case CONSTANTS.PASS_ARGS:
-      expect(content).to.equal(`${SQUASH_PASS_ARGS[0]} "$@"`);
+      expect(content[1]).to.equal(`${SQUASH_PASS_ARGS[0]} "$@"`);
       break;
     default:
-      expect(content).to.equal(SQUASH_FLAG[0]);
+      expect(content[1]).to.equal(SQUASH_FLAG[0]);
       break;
   }
 };


### PR DESCRIPTION
Fixes #96 

This will sign commands by adding a comment "Created by squash" on the first line. The list command will only list the sh files that have this signature.

This allows squash to use the `~/.local/bin` path and avoid manually exporting the PATH. (#86 can be merged after this)

This avoids conflict with other files 

Check everything which applies

- [x] I have added the issue number for which this pull request is created.
